### PR TITLE
Revert "Generate cache_key by argument binding inside function"

### DIFF
--- a/cachext/cache.py
+++ b/cachext/cache.py
@@ -1,5 +1,4 @@
 import functools
-import inspect
 
 
 DEFAULT_KEY_TYPES = (str, int, float, bool)
@@ -17,10 +16,9 @@ def norm_cache_key(v):
 
 
 def default_key(f, *args, **kwargs):
-    args = inspect.signature(f).bind(*args, **kwargs)
-    args.apply_defaults()
-    keys = ["{}={}".format(k, norm_cache_key(v))
-            for k, v in args.arguments.items()]
+    keys = [norm_cache_key(v) for v in args]
+    keys += sorted(
+        ['{}={}'.format(k, norm_cache_key(v)) for k, v in kwargs.items()])
     return 'default.{}.{}.{}'.format(f.__module__, f.__name__, '.'.join(keys))
 
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -23,13 +23,7 @@ def test_default_key():
         cache.default_key(tmp, [], b=b'hello')
 
     key = cache.default_key(tmp, b'hello', b=True, c=None)
-    assert key == 'default.{}.{}.{}'.format(tmp.__module__, tmp.__name__, 'a=hello.b=True.c=None')
-
-    key = cache.default_key(tmp, 1)
-    assert key == cache.default_key(tmp, 1, 2)
-    assert key == cache.default_key(tmp, 1, b=2)
-    assert key == cache.default_key(tmp, a=1, b=2)
-    assert key == cache.default_key(tmp, b=2, c=None, a=1)
+    assert key == 'default.{}.{}.{}'.format(tmp.__module__, tmp.__name__, 'hello.b=True.c=None')
 
 
 def test_cache_ext(app):


### PR DESCRIPTION
Reverts shanbay/cachext#3

performance issue